### PR TITLE
Implement IncomesService.addIncome and add incomes to database

### DIFF
--- a/api/src/controllers/IncomesController.ts
+++ b/api/src/controllers/IncomesController.ts
@@ -10,10 +10,12 @@ class IncomesController {
       return;
     }
 
-    const { amount, frequency } = req.body;
     const incomesService = new IncomesService(account);
-    const income = await incomesService.addIncome(amount, frequency);
-    res.status(200).send({ income });
+    if (!incomesService.addIncome(req.body)) {
+      res.status(400).send({ error: 'Unable to add income' });
+      return;
+    }
+    res.status(200).send({ message: 'Income added' });
   }
 }
 

--- a/api/src/repositories/IncomesRepository.ts
+++ b/api/src/repositories/IncomesRepository.ts
@@ -1,0 +1,36 @@
+import { ObjectId } from 'mongodb';
+import Database from './Database';
+
+export interface IncomesModel {
+  _id?: ObjectId;
+  amount: number;
+  frequency: string;
+}
+
+class IncomesRepository {
+  static async addIncomeByUserId(
+    userId: ObjectId,
+    model: IncomesModel,
+  ): Promise<Boolean> {
+    const mongo = await Database.getInstance();
+    try {
+      const result = await mongo.db.collection('incomes').updateOne(
+        { userId },
+        {
+          $push: {
+            incomes: model,
+          },
+        },
+        {
+          upsert: true,
+        },
+      );
+      return result.modifiedCount === 1 || result.upsertedCount === 1;
+    } catch (error) {
+      console.error(error);
+    }
+    return false;
+  }
+}
+
+export default IncomesRepository;

--- a/api/src/repositories/UsersRepository.ts
+++ b/api/src/repositories/UsersRepository.ts
@@ -10,9 +10,7 @@ export interface UserModel {
 }
 
 class UsersRepository {
-  constructor() {}
-
-  async create(model: UserModel): Promise<UserModel | null> {
+  static async create(model: UserModel): Promise<UserModel | null> {
     const mongo = await Database.getInstance();
     try {
       const { insertedId } = await mongo.db
@@ -27,7 +25,7 @@ class UsersRepository {
     return null;
   }
 
-  async selectByEmail(email: string): Promise<UserModel | null> {
+  static async selectByEmail(email: string): Promise<UserModel | null> {
     const mongo = await Database.getInstance();
     try {
       return mongo.db
@@ -39,7 +37,7 @@ class UsersRepository {
     return null;
   }
 
-  async selectById(id: string): Promise<UserModel | null> {
+  static async selectById(id: string): Promise<UserModel | null> {
     const mongo = await Database.getInstance();
     try {
       return mongo.db

--- a/api/src/requests/AddIncomeSchema.json
+++ b/api/src/requests/AddIncomeSchema.json
@@ -2,16 +2,34 @@
     "type": "object",
     "required": [
         "amount",
-        "frequency"
+        "description",
+        "frequency",
+        "isEnding",
+        "endDate",
+        "isFixed"
     ],
     "properties": {
         "amount": {
             "type": "number",
             "minimum": 0
         },
+        "description": {
+            "type": "string",
+            "minLength": 1
+        },
         "frequency": {
             "type": "string",
             "minLength": 1
+        },
+        "isEnding": {
+            "type": "boolean"
+        },
+        "endDate": {
+            "type": "string",
+            "minLength": 0
+        },
+        "isFixed": {
+            "type": "boolean"
         }
     }
 }

--- a/api/src/routes/incomes.ts
+++ b/api/src/routes/incomes.ts
@@ -5,6 +5,7 @@ import auth from '../middleware/auth';
 import getRouteHandler from './routeHandler';
 import IncomesController from '../controllers/IncomesController';
 
+// \todo: schema needs to be changed to accept dates and frequency objectIds
 import AddIncomeSchema from '../requests/AddIncomeSchema.json';
 
 type ValidateFunction = (schema: { body?: any }) => RequestHandler;

--- a/api/src/services/IncomesService.ts
+++ b/api/src/services/IncomesService.ts
@@ -1,3 +1,7 @@
+import IncomesRepository, {
+  IncomesModel,
+} from '../repositories/IncomesRepository';
+
 import { User } from './UsersService';
 
 class IncomesService {
@@ -6,13 +10,8 @@ class IncomesService {
     this.account = account;
   }
 
-  async addIncome(amount, frequency) {
-    // \todo use this.account to add income to database
-    return {
-      id: 123,
-      amount,
-      frequency,
-    };
+  async addIncome(income: IncomesModel): Promise<Boolean> {
+    return IncomesRepository.addIncomeByUserId(this.account._id, income);
   }
 }
 

--- a/api/src/services/UsersService.ts
+++ b/api/src/services/UsersService.ts
@@ -14,8 +14,7 @@ class UsersService {
   static async create(body: CreateUserInput): Promise<any> {
     const { password, email, firstName, lastName } = body;
     const hashedPassword = await AuthService.geHashedPassword(password);
-    const usersRepo = new UsersRepository();
-    return usersRepo.create({
+    return UsersRepository.create({
       firstName,
       lastName,
       email,
@@ -24,13 +23,11 @@ class UsersService {
   }
 
   static async selectByEmail(email: string): Promise<User | null> {
-    const usersRepo = new UsersRepository();
-    return usersRepo.selectByEmail(email);
+    return UsersRepository.selectByEmail(email);
   }
 
   static async selectById(id: string): Promise<User | null> {
-    const usersRepo = new UsersRepository();
-    return usersRepo.selectById(id);
+    return UsersRepository.selectById(id);
   }
 }
 

--- a/api/test-integration/incomes/add-income.test.ts
+++ b/api/test-integration/incomes/add-income.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it, xit } from '@jest/globals';
 describe.skip('POST /incomes', () => {
   it('should return an error for missing amount', async () => {
     const response = await global.request.post('/api/incomes').send({
-      frequency: 'weekly',
+      description: "Mom's pay",
+      frequency: 'bi-weekly',
+      isEnding: false,
+      endDate: '',
+      isFixed: true,
     });
 
     expect(response.status).toEqual(400);
@@ -12,7 +16,11 @@ describe.skip('POST /incomes', () => {
 
   it('should return an error for missing frequency', async () => {
     const response = await global.request.post('/api/incomes').send({
-      amount: 1500,
+      amount: 4200,
+      description: "Mom's pay",
+      isEnding: false,
+      endDate: '',
+      isFixed: true,
     });
 
     expect(response.status).toEqual(400);
@@ -20,17 +28,25 @@ describe.skip('POST /incomes', () => {
 
   it('should return error due to empty frequency string', async () => {
     const response = await global.request.post('/api/incomes').send({
-      amount: 1500,
+      amount: 4200,
+      description: "Mom's pay",
       frequency: '',
+      isEnding: false,
+      endDate: '',
+      isFixed: true,
     });
 
     expect(response.status).toEqual(400);
   });
 
-  it('should return income', async () => {
+  it('should successfully add income', async () => {
     const response = await global.request.post('/api/incomes').send({
-      amount: 1500,
-      frequency: 'weekly',
+      amount: 4200,
+      description: "Mom's pay",
+      frequency: 'bi-weekly',
+      isEnding: false,
+      endDate: '',
+      isFixed: true,
     });
 
     expect(response.status).toEqual(200);

--- a/api/test/services/IncomesService.test.ts
+++ b/api/test/services/IncomesService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@jest/globals';
+import { ObjectId } from 'mongodb';
+
+import IncomesService from '../../src/services/IncomesService';
+
+import IncomesRepository from '../../src/repositories/IncomesRepository';
+
+describe('IncomesService', () => {
+  it('should add incomes to user', async () => {
+    // This test is pointless right now because it's just testing that the mock works
+    // but it's here in case the addIncome method changes in future
+
+    const income = {
+      amount: 4200,
+      description: "Mom's pay",
+      frequency: 'bi-weekly',
+      isEnding: false,
+      endDate: '',
+      isFixed: true,
+    };
+
+    IncomesRepository.addIncomeByUserId = jest.fn().mockResolvedValue(true);
+
+    const incomesService = new IncomesService({
+      _id: new ObjectId('123456123456123456123456'),
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test-user@email.com',
+      password: 'password',
+    });
+
+    const result = await incomesService.addIncome(income);
+    expect(result).toEqual(true);
+  });
+});


### PR DESCRIPTION
IncomesService.addIncome is now implemented, and incomes are now added to the database into an incomes array in a incomes document which is connected to the user. 

<img width="763" alt="image" src="https://github.com/markCwatson/budgetpals/assets/68235366/4d1dc864-3b10-4737-aae8-6059e8ebe2ee">

Note 1: added a todo which I'll create an issue for (schema needs to be changed to accept dates and frequency objectIds)
Note 2: the integration tests still can't be run until the test database is setup (there is already an open issue for this)

Resolve #12 
Resolve #15